### PR TITLE
Docs: Add environment variable configuration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,26 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Configuration
+
+This application requires certain environment variables to be set to function correctly. These variables are used to authenticate with the Google Sheets API and to specify which sheet to load.
+
+Create a file named `.env.local` in the root of your project and add the following content:
+
+```
+GOOGLE_SHEETS_CLIENT_EMAIL=your_google_service_account_email@developer.gserviceaccount.com
+GOOGLE_SHEETS_PRIVATE_KEY=-----BEGIN PRIVATE KEY-----\nYourPrivateKeyHere\n-----END PRIVATE KEY-----\n
+NEXT_PUBLIC_GOOGLE_SHEET_ID=your_google_sheet_id
+```
+
+**Explanation of Variables:**
+
+*   `GOOGLE_SHEETS_CLIENT_EMAIL`: The email address of your Google Cloud service account.
+*   `GOOGLE_SHEETS_PRIVATE_KEY`: The private key for your Google Cloud service account. Make sure to replace `\n` with actual newlines if you are copying this from a JSON key file.
+*   `NEXT_PUBLIC_GOOGLE_SHEET_ID`: The ID of the Google Sheet you want to edit. The `NEXT_PUBLIC_` prefix is important as it allows Next.js to expose this variable to the browser.
+
+**Important:**
+*   Do not commit your `.env.local` file to version control. Add `.env.local` to your `.gitignore` file if it's not already there.
+*   You can obtain Google Cloud service account credentials from the [Google Cloud Console](https://console.cloud.google.com/). You will need to enable the Google Sheets API for your project.
+*   The Google Sheet ID can be found in the URL of your Google Sheet. For example, in `https://docs.google.com/spreadsheets/d/your_google_sheet_id/edit`, `your_google_sheet_id` is the ID.


### PR DESCRIPTION
Explain how to set up the GOOGLE_SHEETS_CLIENT_EMAIL, GOOGLE_SHEETS_PRIVATE_KEY, and NEXT_PUBLIC_GOOGLE_SHEET_ID environment variables using a .env.local file.

This is necessary for the application to connect to Google Sheets and load the specified sheet.